### PR TITLE
Add practice directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-other_sols/
-.kattisrc
 **/*.out
-how_to_test/
-venv/
-
 **/*.o
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 **/*.out
 **/*.o
-
+practice/


### PR DESCRIPTION
I added a practice area where I copy the tests and interface from the completed problem, then practice finishing the implementation. I don't want this in the main repo, it is meant to be created and destroyed at will.